### PR TITLE
fix: Axe DevTools Critical Issues

### DIFF
--- a/src/templates/IndexPage/Component.tsx
+++ b/src/templates/IndexPage/Component.tsx
@@ -27,7 +27,13 @@ export const Component: React.VFC<ComponentProps> = ({
       <section className={clsx(['w-full'], ['h-96'])}>
         <div className={clsx(['w-full'], ['h-full'], ['relative'])}>
           {url && (
-            <Image src={url} layout="fill" objectFit="contain" unoptimized />
+            <Image
+              src={url}
+              title="tohohoify generate image"
+              layout="fill"
+              objectFit="contain"
+              unoptimized
+            />
           )}
         </div>
       </section>

--- a/src/templates/IndexPage/molecules/ClipboardButton/Component.tsx
+++ b/src/templates/IndexPage/molecules/ClipboardButton/Component.tsx
@@ -25,6 +25,7 @@ export const Component: React.VFC<ComponentProps> = ({
     )}
     onClick={handleClick}
   >
+    <span className={clsx('sr-only')}>Clipboard Copy</span>
     <FontAwesomeIcon
       icon={faClipboard}
       className={clsx(['text-lg'], 'text-white')}


### PR DESCRIPTION
## Details
Use to [axe DevTools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) to resolve critical accessibility issues.

### Buttons must have discernible text

Added identifiable text to the clipboard button ([679ddc5](https://github.com/SnO2WMaN/tohohoify/commit/679ddc50f57c5aa8b5176ae6eb254be5e37e262e)).

At first I tried to solve this using `aria-label`, but [`@shopify/jsx-no-hardcoded-content` rule](https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/docs/rules/jsx-no-hardcoded-content.md) didn't allow me to override it, so I modified it to include the text and make it `sr-only` readable.

### Images must have alternate text
Added information about what this img is by adding the title attribute ([b09f4af](https://github.com/SnO2WMaN/tohohoify/commit/b09f4afaeb99edeb5ba42c384f751859e9ee9ad9)).

Normally, it would be a good idea to add an `alt` attribute, but since this is an image generator, the meaning of the image will also change each time it is generated.
This critical issue was resolved by using the title attribute instead of the `alt` attribute, referring to [the Living Standard's Images whose contents are not known section](https://html.spec.whatwg.org/multipage/images.html#a-key-part-of-the-content).
A better thing to do would have been to describe the image in `<figcaption>`, but that would have changed the look of the site, so I didn't go that far to fix it.

## Results
<table>
<tr>
	<td>Currently
	<td>Fixed
<tr>
	<td><img width="640" alt="Currently: Axe DevTools Issues Screenshot" src="https://user-images.githubusercontent.com/1996642/124345796-f5ba8e00-dc15-11eb-86ab-6c933cc2bccf.png">
	<td><img width="640" alt="Fixed: Axe DevTools Issues Screenshot" src="https://user-images.githubusercontent.com/1996642/124345794-f18e7080-dc15-11eb-9f23-917fd7fab15b.png">
</table>

